### PR TITLE
Separated path of patterns and relative path of files

### DIFF
--- a/secretscanning/__main__.py
+++ b/secretscanning/__main__.py
@@ -19,7 +19,7 @@ __TEMPLATE__ = os.path.join(__here__, "templates")
 parser = argparse.ArgumentParser(description="Validate a directory of files.")
 parser.add_argument("--debug", action="store_true", help="Print debug messages")
 parser.add_argument("-p", "--path", default="./", help="Directory to scan")
-parser.add_argument("--cwd", default="./", help="Current Working Directory")
+parser.add_argument("--cwd", default=os.getcwd(), help="Set Current Working Directory")
 
 parser_modes = parser.add_argument_group("GitHub")
 parser.add_argument(
@@ -85,6 +85,7 @@ if __name__ == "__main__":
         # Markdown mode
         if arguments.markdown:
             createMarkdown(
+                path,
                 os.path.join(pattern_path, "README.md"),
                 templates=arguments.templates,
                 template=arguments.templates_patterns,
@@ -130,7 +131,8 @@ if __name__ == "__main__":
 
     if arguments.markdown:
         createMarkdown(
-            os.path.join(arguments.cwd, "README.md"),
+                path,
+                "README.md",
                 templates=arguments.templates,
                 template=arguments.templates_main,
             configs=configs,

--- a/secretscanning/markdown.py
+++ b/secretscanning/markdown.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import logging
 
 from jinja2 import Environment, FileSystemLoader
@@ -7,7 +8,7 @@ from secretscanning import __here__
 from secretscanning.patterns import *
 
 
-def createMarkdown(path: str, templates: str = __here__, template: str = "template.md", **data) -> str:
+def createMarkdown(root: str, path: str, templates: str = __here__, template: str = "template.md", **data) -> str:
     logging.info(f"Creating markdown :: {path}")
 
     logging.info(f"Template :: {templates}")
@@ -17,6 +18,6 @@ def createMarkdown(path: str, templates: str = __here__, template: str = "templa
 
     output_from_parsed_template = template.render(data)
 
-    with open(path, "w") as f:
+    with open(os.path.join(root, path), "w") as f:
         f.write(output_from_parsed_template)
     return output_from_parsed_template

--- a/secretscanning/patterns.py
+++ b/secretscanning/patterns.py
@@ -89,6 +89,8 @@ class PatternsConfig:
 
     path: Optional[str] = field(default=None)
 
+    display: bool = field(default=False)
+
     def __post_init__(self):
         _tmp = self.patterns
         self.patterns = []
@@ -122,17 +124,19 @@ def loadPatternFiles(path: str) -> Dict[str, PatternsConfig]:
     for root, dirs, files in os.walk(path):
         for file in files:
             if file == "patterns.yml":
-                path = os.path.join(root, file)
-                logging.debug(f"Found patterns file: {path}")
+                pattern_path = os.path.join(root, file)
+                logging.debug(f"Found patterns file: {pattern_path}")
 
-                with open(path) as f:
+                with open(pattern_path) as f:
                     data = yaml.safe_load(f)
 
-                    config = PatternsConfig(path=path, **data)
+                    relative_path = os.path.join(".", os.path.relpath(pattern_path, path))
+
+                    config = PatternsConfig(path=relative_path, **data)
 
                     logging.debug(
                         f"Loaded :: PatternsConfig('{config.name}' patterns='{len(config.patterns)})'"
                     )
 
-                    patterns[path] = config
+                    patterns[relative_path] = config
     return patterns


### PR DESCRIPTION
This allows clean writing of `README.md` files.

There's the path we're walking, and we retain the relative path of each file under that.

We use that relative path in the markdown generation, and write to the full absolute path location when we write the file itself.