### PR TITLE
Fix action

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -16,11 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-
       - name: Get Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db #v2.1.0

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,7 @@ runs:
       run: |
         echo "::group::Running Secret Scanning tools: ${INPUTS_MODE}"
 
+        cd ${{ github.action_path }}
         python3 -m secretscanning \
           "--${INPUTS_MODE}" \
           --github-token "${INPUTS_TOKEN}" \

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
   template-patterns:
     description: PATTERNS template name
 
+  path:
+    description: Path to scan
+    default: ${{ github.workspace }}
+
   argvs:
     description: Additional arguments
 
@@ -49,6 +53,7 @@ runs:
       shell: bash
       env:
         INPUTS_MODE: ${{ inputs.mode }}
+        INPUTS_PATH: ${{ inputs.path }}
         INPUTS_TOKEN: ${{ inputs.token }}
         INPUTS_REPOSITORY: ${{ inputs.repository }}
         INPUTS_TEMPLATES_PATH: ${{ inputs.templates-path }}
@@ -60,6 +65,7 @@ runs:
         cd ${{ github.action_path }}
         python3 -m secretscanning \
           "--${INPUTS_MODE}" \
+          --path "${INPUTS_PATH}" \
           --github-token "${INPUTS_TOKEN}" \
           --github-repository "${INPUTS_REPOSITORY}" \
           ${INPUTS_TEMPLATES_PATH:+--templates "${INPUTS_TEMPLATES_PATH}"} \


### PR DESCRIPTION
The Action wasn't working since the `secretscanning` module isn't resolved.

I've fixed that by changing directory to the Action path before trying to use it, and added setting the `--path` using an input to the Action (the GitHub workspace, by default).

I also removed `setup-python` from the `self-test.yml` workflow since that's done in the Action on the GitHub hosted runners.