### PR TITLE
Update CODEOWNERS to include oss-maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
 # This project is maintained by:
-*   @GeekMasher
-*   @aegilops
+*   @oss-maintainers


### PR DESCRIPTION
This pull request updates the project maintainers in the `CODEOWNERS` file to reflect the current team structure.